### PR TITLE
Apply Prettier and ESLint, and Configure VS Code for Auto-formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,36 +5,37 @@ module.exports = {
     node: true,
   },
   extends: [
-    'airbnb',
-    'eslint:recommended',
-    'plugin:react/recommended',
-    'plugin:react/jsx-runtime',
-    'plugin:@next/next/recommended',
-    'prettier',
+    "airbnb",
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:@next/next/recommended",
+    "prettier",
   ],
   overrides: [
     {
       env: {
         node: true,
       },
-      files: [
-        '.eslintrc.{js,cjs}',
-      ],
+      files: [".eslintrc.{js,cjs}"],
       parserOptions: {
-        sourceType: 'script',
+        sourceType: "script",
       },
     },
   ],
   parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
+    ecmaVersion: "latest",
+    sourceType: "module",
   },
   rules: {
-    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
-    'react/jsx-props-no-spreading': [1, {
-      custom: 'ignore',
-    }],
-    'react/prop-types': [0],
+    "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx"] }],
+    "react/jsx-props-no-spreading": [
+      1,
+      {
+        custom: "ignore",
+      },
+    ],
+    "react/prop-types": [0],
     "react/no-danger": "off",
   },
 };

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 This is a [Next.js](https://nextjs.org/) blog using [Notions Public API](https://developers.notion.com).
 
-__Demo:__ [https://notion-blog-nextjs-coral.vercel.app](https://notion-blog-nextjs-coral.vercel.app)
+**Demo:** [https://notion-blog-nextjs-coral.vercel.app](https://notion-blog-nextjs-coral.vercel.app)
 
-__How-it-works/Documentation:__ [https://samuelkraft.com/blog/building-a-notion-blog-with-public-api](https://samuelkraft.com/blog/building-a-notion-blog-with-public-api)
+**How-it-works/Documentation:** [https://samuelkraft.com/blog/building-a-notion-blog-with-public-api](https://samuelkraft.com/blog/building-a-notion-blog-with-public-api)
 
 ## Getting Started
 
@@ -38,11 +38,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fsamuelkraft%2Fnotion-blog-nextjs&env=NOTION_TOKEN,NOTION_DATABASE_ID&envDescription=Please%20add%20NOTION_TOKEN%20and%20NOTION_DATABASE_ID%20that%20is%20required%20to%20connect%20the%20blog%20to%20your%20notion%20account.&envLink=https%3A%2F%2Fdevelopers.notion.com%2Fdocs%2Fgetting-started&project-name=notion-blog-nextjs&repo-name=notion-blog-nextjs&demo-title=Notion%20Blog%20Next%20JS&demo-description=%20This%20is%20a%20Next.js%20blog%20using%20Notions%20Public%20API.&demo-url=notion-blog-nextjs-coral.vercel.app)
 
 #### GitHub Actions
+
 - Deployment workflows are located under `.github/workflows/` in this repository.
 - To use the actions, rename them to remove the `.txt` extensions
 
-
 To be able to deploy on both vercel and gh pages through GitHub actions when merging/pushing to master, add the following as your GitHub Action Secrets (Settings->Secrets->Actions).
+
 1. ORG_ID - Vercel account ID found in account Settings.
 1. PROJECT_ID - Vercel project ID found in project Settings.
 1. VERCEL_TOKEN - Vercel token created in Settings -> Tokens.

--- a/app/article/[slug]/page.js
+++ b/app/article/[slug]/page.js
@@ -1,20 +1,18 @@
-import { Fragment } from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
+import { Fragment } from "react";
+import Head from "next/head";
+import Link from "next/link";
 
-import {
-  getDatabase, getBlocks, getPageFromSlug,
-} from '../../../lib/notion';
-import Text from '../../../components/text';
-import { renderBlock } from '../../../components/notion/renderer';
-import styles from '../../../styles/post.module.css';
+import { getDatabase, getBlocks, getPageFromSlug } from "../../../lib/notion";
+import Text from "../../../components/text";
+import { renderBlock } from "../../../components/notion/renderer";
+import styles from "../../../styles/post.module.css";
 
 // Return a list of `params` to populate the [slug] dynamic segment
 export async function generateStaticParams() {
   const database = await getDatabase();
   return database?.map((page) => {
     const slug = page.properties.Slug?.formula?.string;
-    return ({ id: page.id, slug });
+    return { id: page.id, slug };
   });
 }
 

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,20 +1,18 @@
-import '../styles/globals.css';
+import "../styles/globals.css";
 
-import { Inter } from 'next/font/google';
+import { Inter } from "next/font/google";
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "Kaz's Dev Diary",
-  description: 'Blog description',
+  description: "Blog description",
 };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
-        {children}
-      </body>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,9 +1,10 @@
-import Link from 'next/link';
-import { getDatabase } from '../lib/notion';
-import Text from '../components/text';
-import styles from './index.module.css';
+import Link from "next/link";
+import { getDatabase } from "../lib/notion";
+import Text from "../components/text";
+import styles from "./index.module.css";
 
-export const databaseId = process.env?.NOTION_DATABASE_ID ?? 'NOTION_DATABASE_ID';
+export const databaseId =
+  process.env?.NOTION_DATABASE_ID ?? "NOTION_DATABASE_ID";
 
 export function getDisplayDate(editedDate, createdDate) {
   return editedDate === createdDate
@@ -26,27 +27,44 @@ export default async function Page() {
           <div className={styles.headerContainer}>
             <h1>Kaz&apos;s Dev Diary</h1>
             <div className={styles.logos}>
-              <a href="https://github.com/Kaz-Smino" target="_blank" rel="noreferrer">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <a
+                href="https://github.com/Kaz-Smino"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                 </svg>
               </a>
               <span className={styles.plus}> </span>
-              <a href="https://www.linkedin.com/in/kaz-smino/" target="_blank" rel="noreferrer">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" /></svg>
+              <a
+                href="https://www.linkedin.com/in/kaz-smino/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
+                </svg>
               </a>
             </div>
           </div>
           <p>
-            Implemented with
-            {' '}
-            <strong>Next.js</strong>
+            Implemented with <strong>Next.js</strong>
             <br />
-            this technical blog serves as a platform to document daily learnings.
+            this technical blog serves as a platform to document daily
+            learnings.
             <br />
-            Blog post data is fetched using
-            {' '}
-            <strong>Notion</strong>
+            Blog post data is fetched using <strong>Notion</strong>
             &apos;s API.
           </p>
         </header>
@@ -55,19 +73,19 @@ export default async function Page() {
         <ol className={styles.posts}>
           {posts.map((post) => {
             const editedDate = new Date(post.last_edited_time).toLocaleString(
-              'en-US',
+              "en-US",
               {
-                month: 'short',
-                day: '2-digit',
-                year: 'numeric',
+                month: "short",
+                day: "2-digit",
+                year: "numeric",
               },
             );
             const createdDate = new Date(post.created_time).toLocaleString(
-              'en-US',
+              "en-US",
               {
-                month: 'short',
-                day: '2-digit',
-                year: 'numeric',
+                month: "short",
+                day: "2-digit",
+                year: "numeric",
               },
             );
             const displayDate = getDisplayDate(editedDate, createdDate);

--- a/app/page.test.js
+++ b/app/page.test.js
@@ -1,19 +1,23 @@
 /* eslint-disable no-undef */
-import { getDisplayDate } from './page';
+import { getDisplayDate } from "./page";
 
-describe('Function: getDisplayDate', () => {
-  describe('When edited date is the same as created date', () => {
-    it('should return a string indicating the published date', () => {
-      const date = '2022-01-01';
-      expect(getDisplayDate(date, date)).toBe(`Published: <strong>${date}</strong>`);
+describe("Function: getDisplayDate", () => {
+  describe("When edited date is the same as created date", () => {
+    it("should return a string indicating the published date", () => {
+      const date = "2022-01-01";
+      expect(getDisplayDate(date, date)).toBe(
+        `Published: <strong>${date}</strong>`,
+      );
     });
   });
 
-  describe('When edited date is different from created date', () => {
-    it('should return a string indicating the revised date', () => {
-      const createdDate = '2022-01-01';
-      const editedDate = '2022-01-02';
-      expect(getDisplayDate(editedDate, createdDate)).toBe(`Revised: <strong>${editedDate}</strong>`);
+  describe("When edited date is different from created date", () => {
+    it("should return a string indicating the revised date", () => {
+      const createdDate = "2022-01-01";
+      const editedDate = "2022-01-02";
+      expect(getDisplayDate(editedDate, createdDate)).toBe(
+        `Revised: <strong>${editedDate}</strong>`,
+      );
     });
   });
 });

--- a/components/notion/renderer.js
+++ b/components/notion/renderer.js
@@ -1,46 +1,47 @@
-import { Fragment } from 'react';
-import Link from 'next/link';
+import { Fragment } from "react";
+import Link from "next/link";
+import Image from "next/image";
 
-import Text from '../text';
-import styles from '../../styles/post.module.css';
+import Text from "../text";
+import styles from "../../styles/post.module.css";
 
 export function renderBlock(block) {
   const { type, id } = block;
   const value = block[type];
 
   switch (type) {
-    case 'paragraph':
+    case "paragraph":
       return (
         <p>
           <Text title={value.rich_text} />
         </p>
       );
-    case 'heading_1':
+    case "heading_1":
       return (
         <h1>
           <Text title={value.rich_text} />
         </h1>
       );
-    case 'heading_2':
+    case "heading_2":
       return (
         <h2>
           <Text title={value.rich_text} />
         </h2>
       );
-    case 'heading_3':
+    case "heading_3":
       return (
         <h3>
           <Text title={value.rich_text} />
         </h3>
       );
-    case 'bulleted_list': {
+    case "bulleted_list": {
       return <ul>{value.children.map((child) => renderBlock(child))}</ul>;
     }
-    case 'numbered_list': {
+    case "numbered_list": {
       return <ol>{value.children.map((child) => renderBlock(child))}</ol>;
     }
-    case 'bulleted_list_item':
-    case 'numbered_list_item':
+    case "bulleted_list_item":
+    case "numbered_list_item":
       return (
         <li key={block.id}>
           <Text title={value.rich_text} />
@@ -48,17 +49,16 @@ export function renderBlock(block) {
           {!!value.children && renderNestedList(block)}
         </li>
       );
-    case 'to_do':
+    case "to_do":
       return (
         <div>
           <label htmlFor={id}>
-            <input type="checkbox" id={id} defaultChecked={value.checked} />
-            {' '}
+            <input type="checkbox" id={id} defaultChecked={value.checked} />{" "}
             <Text title={value.rich_text} />
           </label>
         </div>
       );
-    case 'toggle':
+    case "toggle":
       return (
         <details>
           <summary>
@@ -69,28 +69,29 @@ export function renderBlock(block) {
           ))}
         </details>
       );
-    case 'child_page':
+    case "child_page":
       return (
         <div className={styles.childPage}>
           <strong>{value?.title}</strong>
           {block.children.map((child) => renderBlock(child))}
         </div>
       );
-    case 'image': {
-      const src = value.type === 'external' ? value.external.url : value.file.url;
-      const caption = value.caption ? value.caption[0]?.plain_text : '';
+    case "image": {
+      const src =
+        value.type === "external" ? value.external.url : value.file.url;
+      const caption = value.caption ? value.caption[0]?.plain_text : "";
       return (
         <figure>
-          <img src={src} alt={caption} />
+          <Image src={src} alt={caption} width={500} height={300} />
           {caption && <figcaption>{caption}</figcaption>}
         </figure>
       );
     }
-    case 'divider':
+    case "divider":
       return <hr key={id} />;
-    case 'quote':
+    case "quote":
       return <blockquote key={id}>{value.rich_text[0].plain_text}</blockquote>;
-    case 'code':
+    case "code":
       return (
         <pre className={styles.pre}>
           <code className={styles.code_block} key={id}>
@@ -98,38 +99,44 @@ export function renderBlock(block) {
           </code>
         </pre>
       );
-    case 'file': {
-      const srcFile = value.type === 'external' ? value.external.url : value.file.url;
-      const splitSourceArray = srcFile.split('/');
+    case "file": {
+      const srcFile =
+        value.type === "external" ? value.external.url : value.file.url;
+      const splitSourceArray = srcFile.split("/");
       const lastElementInArray = splitSourceArray[splitSourceArray.length - 1];
-      const captionFile = value.caption ? value.caption[0]?.plain_text : '';
+      const captionFile = value.caption ? value.caption[0]?.plain_text : "";
       return (
         <figure>
           <div className={styles.file}>
-            📎
-            {' '}
+            📎{" "}
             <Link href={srcFile} passHref>
-              {lastElementInArray.split('?')[0]}
+              {lastElementInArray.split("?")[0]}
             </Link>
           </div>
           {captionFile && <figcaption>{captionFile}</figcaption>}
         </figure>
       );
     }
-    case 'bookmark': {
+    case "bookmark": {
       const href = value.url;
       return (
-        <a href={href} target="_blank" rel="noreferrer noopener" className={styles.bookmark}>
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer noopener"
+          className={styles.bookmark}
+        >
           {href}
         </a>
       );
     }
-    case 'table': {
+    case "table": {
       return (
         <table className={styles.table}>
           <tbody>
             {block.children?.map((child, index) => {
-              const RowElement = value.has_column_header && index === 0 ? 'th' : 'td';
+              const RowElement =
+                value.has_column_header && index === 0 ? "th" : "td";
               return (
                 <tr key={child.id}>
                   {child.table_row?.cells?.map((cell, i) => (
@@ -145,19 +152,19 @@ export function renderBlock(block) {
         </table>
       );
     }
-    case 'column_list': {
+    case "column_list": {
       return (
         <div className={styles.row}>
           {block.children.map((childBlock) => renderBlock(childBlock))}
         </div>
       );
     }
-    case 'column': {
+    case "column": {
       return <div>{block.children.map((child) => renderBlock(child))}</div>;
     }
     default:
       return `❌ Unsupported block (${
-        type === 'unsupported' ? 'unsupported by Notion API' : type
+        type === "unsupported" ? "unsupported by Notion API" : type
       })`;
   }
 }
@@ -167,7 +174,7 @@ export function renderNestedList(blocks) {
   const value = blocks[type];
   if (!value) return null;
 
-  const isNumberedList = value.children[0].type === 'numbered_list_item';
+  const isNumberedList = value.children[0].type === "numbered_list_item";
 
   if (isNumberedList) {
     return <ol>{value.children.map((block) => renderBlock(block))}</ol>;

--- a/components/text.js
+++ b/components/text.js
@@ -1,4 +1,4 @@
-import styles from '../styles/post.module.css';
+import styles from "../styles/post.module.css";
 
 export default function Text({ title }) {
   if (!title) {
@@ -6,21 +6,19 @@ export default function Text({ title }) {
   }
   return title.map((value) => {
     const {
-      annotations: {
-        bold, code, color, italic, strikethrough, underline,
-      },
+      annotations: { bold, code, color, italic, strikethrough, underline },
       text,
     } = value;
     return (
       <span
         className={[
-          bold ? styles.bold : '',
-          code ? styles.code : '',
-          italic ? styles.italic : '',
-          strikethrough ? styles.strikethrough : '',
-          underline ? styles.underline : '',
-        ].join(' ')}
-        style={color !== 'default' ? { color } : {}}
+          bold ? styles.bold : "",
+          code ? styles.code : "",
+          italic ? styles.italic : "",
+          strikethrough ? styles.strikethrough : "",
+          underline ? styles.underline : "",
+        ].join(" ")}
+        style={color !== "default" ? { color } : {}}
         key={text.content}
       >
         {text.link ? <a href={text.link.url}>{text.content}</a> : text.content}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   transform: {
-    '^.+\\.jsx?$': 'babel-jest',
+    "^.+\\.jsx?$": "babel-jest",
   },
   moduleNameMapper: {
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    "\\.(css|less|scss|sass)$": "identity-obj-proxy",
   },
 };

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1,4 +1,4 @@
-import { Client } from '@notionhq/client';
+import { Client } from "@notionhq/client";
 
 export const revalidate = 3600; // revalidate the data at most every hour
 
@@ -48,7 +48,7 @@ export const getPageFromSlug = async (slug) => {
     const response = await notion.databases.query({
       database_id: databaseId,
       filter: {
-        property: 'Slug',
+        property: "Slug",
         formula: {
           string: {
             equals: slug,
@@ -66,7 +66,7 @@ export const getPageFromSlug = async (slug) => {
 };
 
 export const getBlocks = async (blockID) => {
-  const blockId = blockID.replaceAll('-', '');
+  const blockId = blockID.replaceAll("-", "");
 
   if (!cache[`getBlocks_${blockId}`]) {
     const { results } = await notion.blocks.children.list({
@@ -85,32 +85,34 @@ export const getBlocks = async (blockID) => {
       return block;
     });
 
-    cache[`getBlocks_${blockId}`] = Promise.all(childBlocks).then((blocks) => blocks.reduce((acc, curr) => {
-      if (curr.type === 'bulleted_list_item') {
-        if (acc[acc.length - 1]?.type === 'bulleted_list') {
-          acc[acc.length - 1][acc[acc.length - 1].type].children?.push(curr);
+    cache[`getBlocks_${blockId}`] = Promise.all(childBlocks).then((blocks) =>
+      blocks.reduce((acc, curr) => {
+        if (curr.type === "bulleted_list_item") {
+          if (acc[acc.length - 1]?.type === "bulleted_list") {
+            acc[acc.length - 1][acc[acc.length - 1].type].children?.push(curr);
+          } else {
+            acc.push({
+              id: getRandomInt(10 ** 99, 10 ** 100).toString(),
+              type: "bulleted_list",
+              bulleted_list: { children: [curr] },
+            });
+          }
+        } else if (curr.type === "numbered_list_item") {
+          if (acc[acc.length - 1]?.type === "numbered_list") {
+            acc[acc.length - 1][acc[acc.length - 1].type].children?.push(curr);
+          } else {
+            acc.push({
+              id: getRandomInt(10 ** 99, 10 ** 100).toString(),
+              type: "numbered_list",
+              numbered_list: { children: [curr] },
+            });
+          }
         } else {
-          acc.push({
-            id: getRandomInt(10 ** 99, 10 ** 100).toString(),
-            type: 'bulleted_list',
-            bulleted_list: { children: [curr] },
-          });
+          acc.push(curr);
         }
-      } else if (curr.type === 'numbered_list_item') {
-        if (acc[acc.length - 1]?.type === 'numbered_list') {
-          acc[acc.length - 1][acc[acc.length - 1].type].children?.push(curr);
-        } else {
-          acc.push({
-            id: getRandomInt(10 ** 99, 10 ** 100).toString(),
-            type: 'numbered_list',
-            numbered_list: { children: [curr] },
-          });
-        }
-      } else {
-        acc.push(curr);
-      }
-      return acc;
-    }, []));
+        return acc;
+      }, []),
+    );
   }
   return cache[`getBlocks_${blockId}`];
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,8 +2,18 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    Fira Sans,
+    Droid Sans,
+    Helvetica Neue,
+    sans-serif;
 }
 
 body {


### PR DESCRIPTION
This PR applies Prettier and ESLint to the codebase for consistent code style and linting. Changes include:

- Formatted code with `npx prettier --write .`
- Fixed ESLint warnings with `npx eslint --fix .`
- Replaced `<img>` tags with Next.js `<Image />` component
- Configured VS Code extensions Prettier ESLint and ESLint to format on save